### PR TITLE
Schema changes in state and user demographic table

### DIFF
--- a/sql/V1__Nucleus_DB_Baseline.sql
+++ b/sql/V1__Nucleus_DB_Baseline.sql
@@ -1608,6 +1608,8 @@ ALTER TABLE ONLY standard_framework
 ALTER TABLE ONLY state
     ADD CONSTRAINT state_pkey PRIMARY KEY (id);
 
+CREATE INDEX state_country_id_idx ON state USING btree (country_id);
+
 
 --
 -- Name: taxonomy_code_code_key; Type: CONSTRAINT; Schema: public; Owner: nucleus; Tablespace: 

--- a/sql/V1__Nucleus_DB_Baseline.sql
+++ b/sql/V1__Nucleus_DB_Baseline.sql
@@ -871,8 +871,8 @@ ALTER TABLE standard_framework OWNER TO nucleus;
 --
 
 CREATE TABLE state (
-    state_id bigint NOT NULL,
-    country_id bigint NOT NULL,
+    id bigserial NOT NULL,
+    country_id bigint  NULL,
     name character varying(2000) NOT NULL,
     code character varying(1000) NOT NULL,
     created_at timestamp without time zone DEFAULT timezone('UTC'::text, now()) NOT NULL,
@@ -1188,7 +1188,7 @@ CREATE TABLE user_demographic (
     firstname character varying(100),
     lastname character varying(100),
     parent_user_id character varying(36),
-    user_category user_category_type NOT NULL,
+    user_category user_category_type  NULL,
     created_at timestamp without time zone DEFAULT timezone('UTC'::text, now()) NOT NULL,
     updated_at timestamp without time zone DEFAULT timezone('UTC'::text, now()) NOT NULL,
     last_login timestamp without time zone,
@@ -1606,7 +1606,7 @@ ALTER TABLE ONLY standard_framework
 --
 
 ALTER TABLE ONLY state
-    ADD CONSTRAINT state_pkey PRIMARY KEY (state_id, country_id);
+    ADD CONSTRAINT state_pkey PRIMARY KEY (id);
 
 
 --

--- a/sql/V1__Nucleus_DB_Baseline.sql
+++ b/sql/V1__Nucleus_DB_Baseline.sql
@@ -434,7 +434,8 @@ CREATE TABLE country (
     name character varying(2000) NOT NULL,
     code character varying(1000) NOT NULL,
     created_at timestamp without time zone DEFAULT timezone('UTC'::text, now()) NOT NULL,
-    updated_at timestamp without time zone DEFAULT timezone('UTC'::text, now()) NOT NULL
+    updated_at timestamp without time zone DEFAULT timezone('UTC'::text, now()) NOT NULL,
+    creator_id character varying(36)
 );
 
 
@@ -833,7 +834,8 @@ CREATE TABLE school (
     name character varying(2000) NOT NULL,
     code character varying(1000) NOT NULL,
     created_at timestamp without time zone DEFAULT timezone('UTC'::text, now()) NOT NULL,
-    updated_at timestamp without time zone DEFAULT timezone('UTC'::text, now()) NOT NULL
+    updated_at timestamp without time zone DEFAULT timezone('UTC'::text, now()) NOT NULL,
+    creator_id character varying(36)
 );
 
 
@@ -848,7 +850,8 @@ CREATE TABLE school_district (
     name character varying(2000) NOT NULL,
     code character varying(1000) NOT NULL,
     created_at timestamp without time zone DEFAULT timezone('UTC'::text, now()) NOT NULL,
-    updated_at timestamp without time zone DEFAULT timezone('UTC'::text, now()) NOT NULL
+    updated_at timestamp without time zone DEFAULT timezone('UTC'::text, now()) NOT NULL,
+    creator_id character varying(36)
 );
 
 
@@ -876,7 +879,8 @@ CREATE TABLE state (
     name character varying(2000) NOT NULL,
     code character varying(1000) NOT NULL,
     created_at timestamp without time zone DEFAULT timezone('UTC'::text, now()) NOT NULL,
-    updated_at timestamp without time zone DEFAULT timezone('UTC'::text, now()) NOT NULL
+    updated_at timestamp without time zone DEFAULT timezone('UTC'::text, now()) NOT NULL,
+    creator_id character varying(36)
 );
 
 


### PR DESCRIPTION
* Changed user_category as nullable, since we wont  set the user category  as "other" by default. On first signup if it's null, FE will  force the user to update the category.
* Renamed state_id as id in state table.
* creator_id column is needed in school,school_district, state and country tables, the entries created by system will have creator id as null, created by user as the creator id value.
 